### PR TITLE
adjust profile data

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -21,19 +21,6 @@ export default class StorageServer extends Componentry.Module {
 
     static async mint(connector) {
         const server = new StorageServer(connector);
-        /*
-            environment variables for storj example:
-
-            STORAGE_PROFILE=storj
-            STORAGE_CREDENTIALS='{"STORJ":{
-                "BUCKET":"metric-storage",
-                "ACCESS_KEY":"",
-                "SECRET":""
-            }}'
-        */
-        try { connector.profile = JSON.parse(process.env.STORAGE_CREDENTIALS); }
-        catch  { connector.profile = process.env.STORAGE_CREDENTIALS; }
-        process.env.MEDIA_STORAGE = process.env.STORAGE_PROFILE;
         server.storage = await StorageBridge.mint(server);
         return server;
     }
@@ -44,6 +31,7 @@ export default class StorageServer extends Componentry.Module {
         router.use(fileUpload({ limits: {fileSize: 50 * 1024 * 1024}}));
         router.use('/storage/list', listRoutes(this.storage, this.connector));
         router.use('/storage/item', itemRoutes(this.storage, this.connector));
+        // router.use(this.notFound.bind(this));
         return router;
     }
 

--- a/modules/StorageBridge/AWSStorage.mjs
+++ b/modules/StorageBridge/AWSStorage.mjs
@@ -1,9 +1,9 @@
 import sharp from 'sharp';
-import Index from './index.mjs';
+import StorageBridge from './index.mjs';
 import ImageProcessor from "./ImageProcessor.mjs";
 import { ListObjectsCommand,PutObjectCommand,GetObjectCommand,DeleteObjectCommand, S3Client } from '@aws-sdk/client-s3';
 
-export default class AWSStorage extends Index {
+export default class AWSStorage extends StorageBridge {
 
   constructor(parent, options = {}) {
     super(parent, options);
@@ -11,8 +11,8 @@ export default class AWSStorage extends Index {
     this.initClient();
   }
   initClient() {
-    this.bucketName = this.connector.profile.aws.s3_bucket
-    this.client = new S3Client({region:this.connector.profile.aws.s3_region});
+    this.bucketName = this.connector.profile.AWS.S3_BUCKET
+    this.client = new S3Client({region:this.connector.profile.AWS.S3_REGION});
   }
 
   static async mint(parent, options) {

--- a/server.js
+++ b/server.js
@@ -7,7 +7,6 @@ async function main() {
 
     const app = express();
     app.use(storageModule.routes());
-    app.use(storageModule.notFound.bind(storageModule));
 
     const port = process.env.PORT || 3000;
     app.listen(port, () => {


### PR DESCRIPTION
* Removed the recasting of env vars
* Moved profile for AWS to vault and adapted to syntax to match
* The routes() function is called by componentry for every module provided to init(), in the order listed. Use notFound applied directly applied with no path might cause problems to later modules. The invocation of routes() would have been better to require a namespace, like "/storage" or "/data", but it currently allows each module to add routes to root.
* Renamed class implemented by StorageServer/index.mjs from Index to StorageServer