### PR TITLE
Image Handling and S3 Optimizations

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -21,41 +21,20 @@ export default class StorageServer extends Componentry.Module {
 
     static async mint(connector) {
         const server = new StorageServer(connector);
-        /*
-            environment variables for storj example:
-
-            STORAGE_PROFILE=storj
-            STORAGE_CREDENTIALS='{"STORJ":{
-                "BUCKET":"metric-storage",
-                "ACCESS_KEY":"",
-                "SECRET":""
-            }}'
-        */
-        if (!process.env.STORAGE_CREDENTIALS) {
-            throw new Error("STORAGE_CREDENTIALS is required but not found in environment");
-        }
-        try {
-            const storageCredentials = JSON.parse(process.env.STORAGE_CREDENTIALS);
-            connector.profile = { ...connector.profile, ...storageCredentials };
-        } catch (e) {
-            throw e;
-        }
-        process.env.MEDIA_STORAGE = process.env.STORAGE_PROFILE;
         server.storage = await StorageBridge.mint(server);
         return server;
     }
 
     routes() {
         const router = express.Router();
-
         router.use(
-            '/list',
+            '/storage/list',
             express.json(),
             listRoutes(this.storage, this.connector)
         );
 
         router.use(
-            '/item',
+            '/storage/item',
             itemRoutes(this.storage, this.connector)
         );
         return router;

--- a/modules/MediaPresets.mjs
+++ b/modules/MediaPresets.mjs
@@ -1,0 +1,9 @@
+export default {
+    FB:  { _id:'META', name:'Meta',      options:'scale=900,600,cover' },
+    GG:  { _id:'GG',   name:'Google',    options:'scale=600,600,cover' },
+    OB:  { _id:'OB',   name:'Outbrain',  options:'scale=640,480,cover' },
+    TB:  { _id:'TB',   name:'Taboola',   options:'scale=400,300,cover' },
+    TW:  { _id:'TW',   name:'X/Twitter', options:'scale=400,400,cover' },
+    SEZ: { _id:'SEZ',  name:'Sez.us',    options:'scale=400,400,cover' },
+    icon:{ _id:'icon', name:'Icon',      options:'scale=60,60,cover' }
+};

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/metric-im/storage-server#readme",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.815.0",
+    "@aws-sdk/md5-js": "^3.370.0",
     "@metric-im/componentry": "^1.4.2",
     "axios": "^1.9.0",
     "dotenv": "^16.5.0",

--- a/routes/itemRoutes.mjs
+++ b/routes/itemRoutes.mjs
@@ -1,100 +1,183 @@
 import express from 'express';
 import path from 'path';
+import sharp from 'sharp';
+import MediaPresetsRaw from '../modules/MediaPresets.mjs';
 import { parseRender, getKeyAndBase, checkAcl } from '../lib/utils.mjs';
 import crypto from 'crypto';
+
+const MediaPresets = Object.fromEntries(
+  Object.entries(MediaPresetsRaw).map(([key, { _id, options }]) => {
+    const [, coords] = options.split('=');
+    const [width, height, fit] = coords.split(',');
+    return [_id, { id: _id, width: +width, height: +height, fit }];
+  })
+);
 
 export default function itemRoutes(storage, connector) {
     const router = express.Router();
 
-    router.post('/*filePath', async (req,res) => {
+    const jsonParser = express.json();
+    const rawUpload = express.raw({
+        type: '*/*',
+        limit: '50mb'
+    });
+
+    router.put('/*filePath', jsonParser, async (req,res, next) => {
+        if (!req.is('application/json')) return next();
         const param = Array.isArray(req.params.filePath) ? req.params.filePath.join('/') : req.params.filePath;
         const acct  = Array.isArray(req.params.filePath) ? req.params.filePath[0] : req.params.filePath.split('/')[0];
         if (!checkAcl(connector, acct, 'write')) return res.sendStatus(403);
-        if (!req.files?.file) return res.sendStatus(400);
 
-        const upload = req.files.file;
+        const fullKey = param;
+        const existingMeta = (await storage.getMeta(fullKey)) || {};
+        const now = new Date().toISOString();
+        const mergedMeta = { ...existingMeta, ...req.body, _modified: now, _modifiedBy: connector.profile.userId };
+        await storage.putMeta(fullKey, mergedMeta);
+        return res.json(mergedMeta);
+    });
+
+    router.post('/*filePath', rawUpload, async (req, res) => {
+        const param = Array.isArray(req.params.filePath)
+            ? req.params.filePath.join('/')
+            : req.params.filePath;
+        const acct = Array.isArray(req.params.filePath) ? req.params.filePath[0] : req.params.filePath.split('/')[0];
+
+        if (!checkAcl(connector, acct, 'write')) {
+            return res.sendStatus(403);
+        }
+        const decodedFileName = decodeURIComponent(req.get('X-File-Name'));
+
+        const upload = {
+            name: decodedFileName,
+            data: req.body,
+            mimetype: req.get('Content-Type') || 'application/octet-stream'
+        };
+
+        if (!upload.name) {
+            return res.status(400).json({ error: 'Missing X-File-Name header' });
+        }
+
         const { fullKey, keyBase } = getKeyAndBase(param, upload.name);
-        const existingMeta = await storage.getMeta(fullKey);
+
+        const existingMeta = await storage.getMeta(keyBase);
         if (existingMeta) {
             return res.status(409).json({ error: 'File already exists', key: fullKey });
         }
 
-        await storage.putImage(keyBase, fullKey, upload.mimetype, upload.data);
+        try {
+            await storage.putImage(keyBase, fullKey, upload.mimetype, upload.data);
 
-        const now  = new Date().toISOString();
-        const hash = crypto.createHash('md5').update(upload.data).digest('hex');
-        const meta = { _created: now, _createdBy: connector.profile.userId, _hash: hash };
-        await storage.putMeta(fullKey, meta);
+            const now  = new Date().toISOString();
+            const hash = crypto.createHash('md5').update(upload.data).digest('hex');
+            const ext  = path.extname(fullKey).slice(1);
+            await storage.putMeta(keyBase, { _created: now, _createdBy: connector.profile.userId, _hash: hash, _ext: ext, type: upload.mimetype });
+            return res.status(201).json({ key: fullKey });
 
-        return res.status(201).json({ key: fullKey });
+        } catch (e) {
+            return res.status(500).json({ error: 'Internal Server Error', message: e.message });
+        }
     });
 
-    router.put('/*filePath', async (req,res) => {
-        const raw  = Array.isArray(req.params.filePath) ? req.params.filePath.join('/') : req.params.filePath;
+    router.put('/*filePath', rawUpload, async (req, res) => {
+        const param = Array.isArray(req.params.filePath)
+            ? req.params.filePath.join('/')
+            : req.params.filePath;
         const acct = Array.isArray(req.params.filePath) ? req.params.filePath[0] : req.params.filePath.split('/')[0];
         if (!checkAcl(connector, acct, 'write')) return res.sendStatus(403);
 
-        const { path: param, engine } = parseRender(raw);
-        const urlExt = path.extname(param).toLowerCase();
+        const decodedFileName = decodeURIComponent(req.get('X-File-Name'));
 
-        if (req.is('application/json')) {
-            let fullKey = param;
-            if (!urlExt) {
-                const existing = await storage.getMeta(param);
-                if (!existing?._ext) return res.sendStatus(404);
-                fullKey = `${param}.${existing._ext}`;
-            }
-            const existingMeta = await storage.getMeta(fullKey) || {};
-            const now          = new Date().toISOString();
-            const mergedMeta   = { ...existingMeta, ...req.body, _modified: now, _modifiedBy: connector.profile.userId }; 
-            await storage.putMeta(fullKey, mergedMeta);
-            return res.json(mergedMeta);
-        }
+        const upload = {
+            name: decodedFileName,
+            data: req.body,
+            mimetype: req.get('Content-Type') || 'application/octet-stream'
+        };
 
-        if (req.files?.file) {
-            const upload = req.files.file;
-            const { fullKey, keyBase } = getKeyAndBase(param, upload.name);
-            
+        if (!upload.name) return res.status(400).json({ error: 'Missing X-File-Name header' });
+
+        const { fullKey, keyBase } = getKeyAndBase(param, upload.name);
+
+        try {
             await storage.putImage(keyBase, fullKey, upload.mimetype, upload.data);
             
-            const now  = new Date().toISOString();
+            const now = new Date().toISOString();
             const hash = crypto.createHash('md5').update(upload.data).digest('hex');
-            const existingMeta = await storage.getMeta(fullKey) || {};
-            const newMeta      = { ...existingMeta, _modified: now, _modifiedBy: connector.profile.userId, _hash: hash };
-            await storage.putMeta(fullKey, newMeta);
-            return res.json({ key: fullKey });
-        }
+            
+            const existingMeta = (await storage.getMeta(keyBase)) || {};
+            const ext          = path.extname(fullKey).slice(1);
+            const newMeta = { ...existingMeta, _modified: now, _modifiedBy: connector.profile.userId, _hash: hash, _ext: ext, type: upload.mimetype };
+            await storage.putMeta(keyBase, newMeta); 
 
-        return res.sendStatus(400);
+            await Promise.all(
+                Object.values(MediaPresets).map(async preset => {
+                    try {
+                        const thumbnailBuffer = await sharp(upload.data)
+                            .resize(preset.width, preset.height, { fit: preset.fit })
+                            .png()
+                            .toBuffer();
+                        await storage.put(
+                            `${keyBase}.${preset.id}`,
+                            thumbnailBuffer,
+                            'image/png'
+                        );
+                    } catch (presetError) {
+                        throw presetError; 
+                    }
+                })
+            );
+
+            return res.json({ key: fullKey });
+        } catch (e) {
+            return res.status(500).json({ error: 'Internal Server Error', message: e.message });
+        }
     });
 
-    router.get('/*filePath', async (req,res) => {
-        const raw  = Array.isArray(req.params.filePath) ? req.params.filePath.join('/') : req.params.filePath;
+    router.get('/*filePath', async (req, res) => {
+        const param = Array.isArray(req.params.filePath) ? req.params.filePath.join('/') : req.params.filePath;
         const acct = Array.isArray(req.params.filePath) ? req.params.filePath[0] : req.params.filePath.split('/')[0];
-        if (!checkAcl(connector, acct, 'read')) return res.sendStatus(403); 
-        const { path: param, engine } = parseRender(raw);
-        if (engine !== 'raw') {
-            // TODO implement RenderEngine plugins
-            return res.sendStatus(501);
+        if (!checkAcl(connector, acct, 'read')) return res.sendStatus(403);
+
+        const urlExt = path.extname(param).slice(1);
+        const preset = MediaPresets[urlExt];
+
+        if (preset) {
+            const keyBase = param.slice(0, -(urlExt.length + 1));
+            try {
+                let buffer = await storage.getImage(keyBase, preset);
+                if (!buffer) {
+                    return res.sendStatus(500);
+                }
+                return res.type('image/png').send(buffer);
+            } catch (err) {
+                return res.sendStatus(500);
+            }
         }
-        let fullKey = param;
-        if (!path.extname(param)) {
-            const meta = await storage.getMeta(param);
-            if (!meta?._ext) return res.sendStatus(404);
-            fullKey = `${param}.${meta._ext}`;
+
+        const { path: parsedPath, engine } = parseRender(param);
+        if (engine !== 'raw') return res.sendStatus(501);
+
+        let fullKey = parsedPath;
+        if (!path.extname(parsedPath)) { 
+            const meta = await storage.getMeta(parsedPath); 
+            if (!meta?._ext) {
+                return res.sendStatus(404);
+            }
+            fullKey = `${parsedPath}.${meta._ext}`;
         }
         const data = await storage.get(fullKey);
-        return data ? res.type('application/octet-stream').send(data) : res.sendStatus(404);
+        return data
+            ? res.type('application/octet-stream').send(data)
+            : res.sendStatus(404);
     });
 
     router.delete('/*filePath', async (req, res) => {
-        const raw  = Array.isArray(req.params.filePath) ? req.params.filePath.join('/') : req.params.filePath;
+        const param = Array.isArray(req.params.filePath) ? req.params.filePath.join('/') : req.params.filePath;
         const acct = Array.isArray(req.params.filePath) ? req.params.filePath[0] : req.params.filePath.split('/')[0];
         if (!checkAcl(connector, acct, 'owner')) return res.sendStatus(403);
         
-        const keyBase = raw.replace(/\.[^/.]+$/, '');
-        const ok = await storage.remove(keyBase);
-        return ok ? res.sendStatus(204) : res.sendStatus(404);
+        const keyBase = param.replace(/\.[^/.]+$/, '');
+        const deleteSuccess = await storage.remove(keyBase);
+        return deleteSuccess ? res.sendStatus(204) : res.sendStatus(404);
     });
 
     return router;


### PR DESCRIPTION
Introduced MediaPresets.mjs to define the standardized image sizes and transformations. The getImage and putImage methods in AWSStorage.mjs leverage the presets. When an image variant is requested, it checks for a cached version on S3. If it's not found, it processes the original image using sharp and caches the new variant back to S3. itemRoutes.mjs automatically generates and stores all MediaPresets variants. Something to consider in production is whether variants should be stored following initial upload or on demand. 

All put and putImage operations include contentMD5 headers for data integrity. The foundation for batch deletion has been added with the DeleteObjectsCommand. The list method in AWSStorage.mjs uses "folder" (common prefix) structure and provides richer metadata.

There is a new PUT /storage/item/*filePath endpoint (with Content-Type: application/json) for metadata update without full file re-upload.

Using express.raw() instead of express-fileupload for raw body parsing on file upload so we can have complete control over binary data. Filenames for uploads are now robustly handled via the X-File-Name header.