### PR TITLE
File Listing Optimizations + Supports More Content Types + Error Handling

### DIFF
--- a/lib/utils.mjs
+++ b/lib/utils.mjs
@@ -1,4 +1,5 @@
 import path from 'path';
+import MediaPresetsRaw from '../modules/MediaPresets.mjs';
 
 // “foo/bar.png#raw” -> { path: "foo/bar.png", engine: "raw" }
 export function parseRender(raw) {
@@ -20,3 +21,11 @@ export function getKeyAndBase(param, uploadName) {
 export function checkAcl(connector, account, action) {
     return true;
 }
+
+export const TransformedMediaPresets = Object.fromEntries(
+  Object.entries(MediaPresetsRaw).map(([key, { _id, options }]) => {
+    const [, coords] = options.split('=');
+    const [width, height, fit] = coords.split(',');
+    return [_id, { id: _id, width: +width, height: +height, fit }];
+  })
+);

--- a/modules/StorageBridge/AWSStorage.mjs
+++ b/modules/StorageBridge/AWSStorage.mjs
@@ -3,15 +3,6 @@ import path from 'path';
 import StorageBridge from './index.mjs';
 import { ListObjectsCommand,PutObjectCommand,GetObjectCommand,DeleteObjectCommand,DeleteObjectsCommand, S3Client } from '@aws-sdk/client-s3';
 import { Md5 } from '@aws-sdk/md5-js';
-import MediaPresetsRaw from '../MediaPresets.mjs';
-
-const MediaPresets = Object.fromEntries(
-  Object.entries(MediaPresetsRaw).map(([key, { _id, options }]) => {
-    const [, coords] = options.split('=');
-    const [width, height, fit] = coords.split(',');
-    return [_id, { id: _id, width: +width, height: +height, fit }];
-  })
-);
 
 export default class AWSStorage extends StorageBridge {
   constructor(parent, options = {}) {

--- a/routes/itemRoutes.mjs
+++ b/routes/itemRoutes.mjs
@@ -50,13 +50,12 @@ export default function itemRoutes(storage, connector) {
 
         const { fullKey, keyBase } = getKeyAndBase(param, upload.name);
 
-        const existingMeta = await storage.getMeta(keyBase);
-        if (existingMeta) {
-            return res.status(409).json({ error: 'File already exists', key: fullKey });
-        }
-
         try {
-            await storage.put(fullKey, upload.data, upload.mimetype);
+            const hasher = crypto.createHash('md5');
+            hasher.update(upload.data);
+            const contentMD5 = hasher.digest('base64');
+        
+            await storage.put(fullKey, upload.data, upload.mimetype, contentMD5);
 
             const now  = new Date().toISOString();
             const hash = crypto.createHash('md5').update(upload.data).digest('hex');


### PR DESCRIPTION
Added TransformedMediaPresets in utils.mjs, so it does not need to be duplicated across modules.

List() method in AWSStorage.mjs has been completely revamped to take on client side filtering. The filtering excludes metadata and preset variant files from the main listing. The return format of the file listings is simplified with consistent metadata structure. 

The redundant md5 calculations were removed, and they are now passed into put and putimage. 

Better content type handling for various file formats.